### PR TITLE
fix: Fixed external actions/getters/state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+Todas as mudanças notáveis neste projeto serão documentadas neste arquivo.
+
+O formato é baseado em [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.0/),
+e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Para encontrar de uma forma mais detalhada todas as mudanças da `versão 2` para a `versão 3`, navegue até o arquivo `/docs/src/pages/start/upgrade-guide.md`.
+Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a versão 3.
+
+### Sobre os "BREAKING CHANGES"
+Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
+
+## Não publicado
+### Adicionado
+- Adicionado `CHANGELOG.md`.
+
+### Corrigido
+- Corrigido interface `StoreModuleOptions` e `ModuleOptions` onde os actions/state/getters era enviado para a instancia da classe ao invés do método `createStoreModule`.
+- Corrigido documentação do `README.md` onde o método era `getStoreModule` ao invés de `createStoreModule`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,6 @@ Todas as mudanças notáveis neste projeto serão documentadas neste arquivo.
 O formato é baseado em [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.0/),
 e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-Para encontrar de uma forma mais detalhada todas as mudanças da `versão 2` para a `versão 3`, navegue até o arquivo `/docs/src/pages/start/upgrade-guide.md`.
-Neste arquivo (CHANGELOG.MD) você encontrará somente as mudanças referentes a versão 3.
-
 ### Sobre os "BREAKING CHANGES"
 Podemos ter pequenas breaking changes sem alterar o `major` version, apesar de serem pequenas, podem alterar o comportamento da funcionalidade caso não seja feita uma atualização, **preste muita atenção** nas breaking changes dentro das versões quando existirem.
 

--- a/README.MD
+++ b/README.MD
@@ -103,7 +103,7 @@ export default storeModule
 ```js
 import storeModule from 'caminho-do-arquivo-store-module.js'
 
-export default storeModule.getStoreModule('users')
+export default storeModule.createStoreModule('users')
 ```
 
 4. Após, isto vamos no arquivo onde foi inicializado o `Vuex`, vamos importar o `users.js` e adicionar ele dentro de `modules`:
@@ -143,17 +143,11 @@ new StoreModule(options: StoreModuleOptions).createStoreModule(
 
 ```ts
 export interface StoreModuleOptions {
-  // actions do vuex ou pinia adicionais
-  actions: ExternalActions
-
   // adapter da store: pinia | vuex
   adapter: StoreModuleAdapter
 
   // instancia do axios
   apiService: ApiService
-
-  // getters do vuex ou pinia adicionais
-  getters: ExternalGetters
 
   // opção para alterar chave identificadora para ser usado como chave primaria
   // configuração global, caso não seja configurado o padrão é "uuid"
@@ -162,12 +156,12 @@ export interface StoreModuleOptions {
   // itens por listagem definidos na action "fetchList"
   // configuração global, caso não seja configurado o padrão é 12
   perPage: number
-
-  // state do vuex ou pinia adicionais 
-  state: ExternalState
 }
 
 export interface ModuleOptions {
+    // actions do vuex ou pinia adicionais
+  actions: ExternalActions
+
   // callback para alterar a url da action "destroy" que tem como parâmetro "{ id }"
   destroyURL: RunCallbackFn<DestroyURL>
 
@@ -183,6 +177,9 @@ export interface ModuleOptions {
   // callback para alterar a url da action "fetchSingle" que tem como parâmetro "{ form, id }"
   fetchSingleURL: RunCallbackFn<FetchSingleURL>
 
+  // getters do vuex ou pinia adicionais
+  getters: ExternalGetters
+
   // opção para alterar chave identificadora para ser usado como chave primaria
   // sobrescreve a configuração global, caso não seja configurado o padrão é
   // configurado global StoreModuleOptions.idKey ou "uuid"
@@ -196,6 +193,9 @@ export interface ModuleOptions {
 
   // opção para alterar a url da action "create"
   createURL: string
+
+  // state do vuex ou pinia adicionais 
+  state: ExternalState
 }
 
 export interface StoreModule {

--- a/src/store-module.ts
+++ b/src/store-module.ts
@@ -1,12 +1,9 @@
 import {
   ActionsFnParams,
   AvailableAdapters,
-  ExternalGetters,
   ModuleOptions,
-  ExternalState,
   StoreModuleClass,
-  StoreModuleOptions,
-  ExternalActions
+  StoreModuleOptions
 } from 'types'
 
 import {
@@ -23,10 +20,6 @@ import {
 } from './module'
 
 export default class StoreModule {
-  private actions: ExternalActions
-  private getters: ExternalGetters
-  private state: ExternalState
-
   private isPinia: boolean
   private isVuex: boolean
 
@@ -41,10 +34,6 @@ export default class StoreModule {
       throw new Error('Wrong adapter, available adapters are: "pinia"(default) or "vuex"')
     }
 
-    this.actions = this.options.actions || {}
-    this.getters = this.options.getters || {}
-    this.state = this.options.state || {}
-
     this.isPinia = (this.options.adapter || 'pinia') === 'pinia'
     this.isVuex = !this.isPinia
   }
@@ -53,6 +42,10 @@ export default class StoreModule {
     options = options || {}
 
     const idKey = options?.idKey || this.options.idKey || 'uuid'
+
+    const actions = options.actions || {}
+    const gettersData = options.getters || {}
+    const stateData = options.state || {}
 
     const actionsPayload: ActionsFnParams = {
       apiService: this.options.apiService,
@@ -69,14 +62,14 @@ export default class StoreModule {
         return {
           ...state(),
 
-          ...this.state
+          ...stateData
         }
       },
 
       getters: {
         ...getters(idKey),
 
-        ...this.getters
+        ...gettersData
       },
 
       actions: {
@@ -89,7 +82,7 @@ export default class StoreModule {
         replace: replace(actionsPayload),
         update: update(actionsPayload),
 
-        ...this.actions
+        ...actions
       }
     }
 

--- a/src/types/actions.ts
+++ b/src/types/actions.ts
@@ -16,6 +16,10 @@ import {
   FetchListApiResponse,
   FetchSingleApiResponse,
 
+  ExternalActions,
+  ExternalGetters,
+  ExternalState,
+
   // ACTIONS PAYLOAD
   FetchListActionPayload,
   FetchFiltersActionPayload,
@@ -53,15 +57,18 @@ export type ActionsPayload = (
 )
 
 export interface ModuleOptions {
+  actions?: ExternalActions
+  createURL?: string
   destroyURL?: RunCallbackFn<DestroyURL>
   fetchFieldOptionsURL?: string
   fetchFiltersURL?: string
   fetchListURL?: string
   fetchSingleURL?: RunCallbackFn<FetchSingleURL>
-  idKey?: string,
-  updateURL?: RunCallbackFn<UpdateURL>
+  getters?: ExternalGetters
+  idKey?: string
   replaceURL?: RunCallbackFn<ReplaceURL>
-  createURL?: string
+  state?: ExternalState
+  updateURL?: RunCallbackFn<UpdateURL>
 }
 
 export type PayloadActionType = (

--- a/src/types/store-module.ts
+++ b/src/types/store-module.ts
@@ -22,13 +22,10 @@ export type ExternalState = Record<string, unknown>
 export type ExternalGetters = Record<keyof (State | ExternalState), unknown> | {}
 
 export interface StoreModuleOptions {
-  actions?: ExternalActions
   adapter: StoreModuleAdapter
   apiService: ApiService
-  getters?: ExternalGetters
   idKey?: string
   perPage?: number
-  state?: ExternalState
 }
 
 export interface StoreModuleClass {


### PR DESCRIPTION
## Não publicado
### Adicionado
- Adicionado `CHANGELOG.md`.

### Corrigido
- Corrigido interface `StoreModuleOptions` e `ModuleOptions` onde os actions/state/getters era enviado para a instancia da classe ao invés do método `createStoreModule`.
- Corrigido documentação do `README.md` onde o método era `getStoreModule` ao invés de `createStoreModule`.
